### PR TITLE
feat: Implement Light/Dark Mode Toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <nav>
             <span><img width="63" src="assets/Netflix_2015_logo.svg" alt=""></span>
             <div class="nav-btn">
+                <button class="btn" id="theme-toggle">☀️</button>
                 <button class="btn btn-lang"><img class="language-switch" src="assets/language-svgrepo-com.svg"><span class="english">English</span><img class="down-arrow" src="assets/down-arrow-svgrepo-com.svg"></button>
                 <button class="btn btn-red-sm">Sign In</button>
             </div>
@@ -180,6 +181,7 @@
     </div>
     <!-- Chatbot Widget End -->
     <script>
+    const GEMINI_API_KEY = "YOUR_GEMINI_API_KEY_HERE";
     const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash-exp:generateContent?key=' + GEMINI_API_KEY;
 
     const chatbotToggle = document.getElementById('chatbot-toggle');
@@ -236,6 +238,29 @@
       botReply = botReply.replace(/[★☆⭐✩✪✫✬✭✮✯✰]/g, '').replace(/\*\*/g, '');
       addMessage('bot', botReply);
     };
+    // --- Dark/Light Mode JavaScript ---
+      const themeToggle = document.getElementById("theme-toggle");
+
+      // Function to set theme
+      function setTheme(theme) {
+        document.body.setAttribute("data-theme", theme);
+        localStorage.setItem("theme", theme); // Save user's preference
+        themeToggle.textContent = theme === "dark" ? "🌙" : "☀️"; // Update button emoji
+      }
+
+      // Check for saved theme preference on load
+      document.addEventListener("DOMContentLoaded", () => {
+        const savedTheme = localStorage.getItem("theme") || "light"; // Default to light if no preference
+        setTheme(savedTheme);
+      });
+
+      // Toggle theme on button click
+      themeToggle.addEventListener("click", () => {
+        const currentTheme = document.body.getAttribute("data-theme");
+        const newTheme = currentTheme === "light" ? "dark" : "light";
+        setTheme(newTheme);
+      });
+
     </script>
 </body>
 

--- a/style.css
+++ b/style.css
@@ -1,306 +1,365 @@
-@import url('https://fonts.googleapis.com/css2?family=Martel+Sans:wght@200;300;400;600;700;800;900&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Martel+Sans:wght@200;300;400;600;700;800;900&display=swap");
 
-@font-face{
-  font-family: 'Netflix Sans Bolder';
-  src: url('fonts/NetflixSans-Bold.otf') format('opentype');
+@font-face {
+  font-family: "Netflix Sans Bolder";
+  src: url("fonts/NetflixSans-Bold.otf") format("opentype");
 }
 
+:root {
+  --main-page-bg: black;
+  --main-text-color: white;
+
+  --section-bg: black;
+  --section-text-color: white;
+
+  --faq-box-bg: rgb(84, 83, 83);
+  --faq-box-hover-bg: rgb(147, 146, 146);
+  --faq-svg-filter: invert(1);
+
+  --first-image-filter: none;
+
+  --btn-text-on-light-bg: white;
+  --btn-lang-svg-filter: invert(1);
+
+  --separation-color: rgb(79, 74, 74);
+  --btn-default-bg: rgb(117, 115, 115);
+  --btn-default-text: white;
+  --btn-red-bg: red;
+  --btn-red-text: white;
+  --input-bg-color: rgba(23, 23, 23, 0.7);
+  --input-border-color: rgba(126, 122, 122, 0.5);
+}
+
+/* Light Mode Overrides for the variables */
+body[data-theme="light"] {
+  --main-page-bg: white;
+  --main-text-color: black;
+
+  --section-bg: #f0f0f0;
+  --section-text-color: black;
+
+  --faq-box-bg: whitesmoke;
+  --faq-box-hover-bg: lightgray;
+  --faq-svg-filter: none;
+
+  --first-image-filter: brightness(1.5) grayscale(0.5);
+
+  --btn-text-on-light-bg: black;
+  --btn-lang-svg-filter: none;
+}
 * {
-    padding: 0;
-    margin: 0;
-    font-family: "Netflix Sans Bolder", "Poppins", sans-serif;
+  padding: 0;
+  margin: 0;
+  font-family: "Netflix Sans Bolder", "Poppins", sans-serif;
 }
 
 body {
-    background-color: black;
+  background-color: var(--main-page-bg);
+  transition: background-color 0.3s ease;
 }
 
 .main {
-    background-image: url(home_page_background_image.jpg);
-    height: 99vh;
-    position: relative;
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: max(1200px, 100vw);
+  background-image: url(home_page_background_image.jpg);
+  height: 99vh;
+  position: relative;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-size: max(1200px, 100vw);
 }
 
 .main .box {
-    height: 99vh;
-    width: 100%;
-    opacity: 0.79;
-    background-color: black;
-    position: absolute;
-    top: 0;
+  height: 99vh;
+  width: 100%;
+  opacity: 0.79;
+  background-color: var(--main-page-bg);
+  position: absolute;
+  top: 0;
 }
 
 nav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    max-width: 65vw;
-    margin: auto;
-    height: 85px;
-    padding: 0 145px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 65vw;
+  margin: auto;
+  height: 85px;
+  padding: 0 145px;
 }
 
 nav img {
-    color: red;
-    width: 130px;
-    position: relative;
-    z-index: 10;
+  color: red;
+  width: 130px;
+  position: relative;
+  z-index: 10;
 }
 
 nav button {
-    position: relative;
-    z-index: 10;
+  position: relative;
+  z-index: 10;
 }
 
 .hero {
-    height: calc(100% - 100px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-direction: column;
-    color: white;
-    position: relative;
-    font-family: "Martel Sans", serif;
-    gap: 23px;
-    padding: 0 30px;
+  height: calc(100% - 100px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  color: var(--main-text-color);
+  position: relative;
+  font-family: "Martel Sans", serif;
+  gap: 23px;
+  padding: 0 30px;
 }
 
-.hero> :first-child {
-    font-weight: bolder;
-    font-size: 48px;
-    text-align: center;
+.hero > :first-child {
+  font-weight: bolder;
+  font-size: 48px;
+  text-align: center;
 }
 
-.hero> :nth-child(2) {
-    font-weight: 400;
-    font-size: 24px;
-    text-align: center;
+.hero > :nth-child(2) {
+  font-weight: 400;
+  font-size: 24px;
+  text-align: center;
 }
 
-.hero> :nth-child(3) {
-    font-weight: 400;
-    font-size: 20px;
-    text-align: center;
+.hero > :nth-child(3) {
+  font-weight: 400;
+  font-size: 20px;
+  text-align: center;
 }
 
 .separation {
-    height: 6px;
-    background-color: rgb(79, 74, 74);
-    position: relative;
-    z-index: 20;
+  height: 6px;
+  background-color: var(--separation-color);
+  position: relative;
+  z-index: 20;
 }
 
-.nav-btn{
-    width: 186px;
-    display: flex;
-    justify-content: space-between;
+.nav-btn {
+  width: 186px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
 }
 
 .btn {
-    padding: 4px 12px;
-    font-weight: 540;
-    background-color: rgb(117, 115, 115);
-    color: white;
-    border-style: none;
-    border-radius: 4px;
+  padding: 4px 12px;
+  font-weight: 540;
+  background-color: var(--btn-default-bg);
+  color: var(--btn-default-text);
+  border-style: none;
+  border-radius: 4px;
+}
+
+#theme-toggle {
+  font-size: 1.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  line-height: 1;
 }
 
 .btn-red {
-    background-color: red;
-    color: white;
-    padding: 3px 24px;
-    font-size: 20px;
-    border-radius: 4px;
-    font-weight: bold;
+  background-color: var(--btn-red-bg);
+  color: var(--btn-red-text);
+  padding: 3px 24px;
+  font-size: 20px;
+  border-radius: 4px;
+  font-weight: bold;
 }
 
-.language-switch{
-    width: 15px;
-    padding: 2px;
+.language-switch {
+  width: 15px;
+  padding: 2px;
 }
 
-.down-arrow{
-    width: 8px;
-    padding: 0 2px;
+.down-arrow {
+  width: 8px;
+  padding: 0 2px;
 }
 
 .hero-buttons {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 14px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
 }
 
 .main input {
-    padding: 7px 101px 8px 14px;
-    color: white;
-    font-size: 12px;
-    font-weight: 900;
-    border-radius: 4px;
-    background-color: rgba(23, 23, 23, 0.7);
-    border: 1px solid rgba(126, 122, 122, 0.5);
+  padding: 7px 101px 8px 14px;
+  color: var(--btn-default-text);
+  font-size: 12px;
+  font-weight: 900;
+  border-radius: 4px;
+  background-color: var(--input-bg-color);
+  border: 1px solid var(--input-border-color);
 }
 
-.btn-lang{
-    background-color: black;
-    border: 1px solid white;
-    color: white;
-    display: flex;
-    align-items: center;
+.btn-lang {
+  background-color: var(--section-bg);
+  border: 1px solid var(--btn-default-text);
+  color: var(--btn-text-on-light-bg);
+  display: flex;
+  align-items: center;
 }
 
-.english{
-    padding: 0 5px;
+.english {
+  padding: 0 5px;
 }
 
 .btn-red-sm {
-    background-color: red;
-    color: white;
+  background-color: var(--btn-red-bg);
+  color: var(--btn-red-text);
 }
 
-.first {
-    display: flex;
-    justify-content: center;
-    max-width: 70vw;
-    margin: auto;
-    color: white;
-    justify-content: center;
-    align-items: center;
+.btn-lang .language-switch,
+.btn-lang .down-arrow {
+  filter: var(--btn-lang-svg-filter);
 }
-@media screen and (max-width:1300px){
-    .first{
-        flex-wrap: wrap;
-    }
-    .secImg img {
-        width: 305px;
-        position: relative;
-        z-index: 10;
-    }
-    .hero> :first-child {
-        font-size: 32px;
-    }
-    .hero> :nth-child(2){
-        font-size: 18px;
-    }
-    .hero> :nth-child(3){
-        font-size: 18px;
-    }
-    nav{
-        max-width: 90vw;
-    }
-    .main input{
-        padding: 7px 53px 8px 14px;
-    }
-    .hero-buttons {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        gap: 14px;
-    }
-    .faq h2{
-        text-align: center;
-        font-size: 32px;
-    }
-    footer{
-        max-width: 90vw;
-    }
-    .footer-item{
-        align-items: center;
-    }
+.first {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  max-width: 100vw;
+  margin: 0;
+  background-color: var(--section-bg);
+  color: var(--section-text-color);
+  padding: 34px 0;
+}
+@media screen and (max-width: 1300px) {
+  .first {
+    flex-wrap: wrap;
+  }
+  .secImg img {
+    width: 305px;
+    position: relative;
+    z-index: 10;
+  }
+  .hero > :first-child {
+    font-size: 32px;
+  }
+  .hero > :nth-child(2) {
+    font-size: 18px;
+  }
+  .hero > :nth-child(3) {
+    font-size: 18px;
+  }
+  nav {
+    max-width: 90vw;
+  }
+  .main input {
+    padding: 7px 53px 8px 14px;
+  }
+  .hero-buttons {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+  }
+  .faq h2 {
+    text-align: center;
+    font-size: 32px;
+  }
+  footer {
+    max-width: 90vw;
+  }
+  .footer-item {
+    align-items: center;
+  }
 }
 
 .secImg img {
-    width: 400px;
-    position: relative;
-    z-index: 10;
+  filter: var(--first-image-filter);
+  width: 400px;
+  position: relative;
+  z-index: 10;
 }
 
 .secImg {
-    position: relative;
-
+  position: relative;
 }
-section.first > div{
-    display: flex;
-    flex-direction: column;
-    padding: 34px 0;
+section.first > div {
+  display: flex;
+  flex-direction: column;
 }
 
-section.first > div :nth-child(1){
-    font-size: 30px;
-    font-weight: bolder;
+section.first > div :nth-child(1) {
+  font-size: 30px;
+  font-weight: bolder;
 }
 
-section.first > div :nth-child(2){
-    font-size: 24px;
+section.first > div :nth-child(2) {
+  font-size: 24px;
 }
-.faq h2{
-    text-align: center;
-    font-size: 48px;
+.faq h2 {
+  text-align: center;
+  font-size: 48px;
 }
-.faq{
-    background-color: black;
-    color: white;
-    padding: 34px;
+.faq {
+  background-color: var(--section-bg);
+  color: var(--section-text-color);
+  padding: 34px;
 }
-.faqbox:hover{
-    background-color: rgb(147, 146, 146);
+.faqbox:hover {
+  background-color: var(--faq-box-hover-bg);
 }
-.faqbox svg{
-    filter: invert(1);
+.faqbox svg {
+  filter: var(--faq-svg-filter);
 }
-.faqbox{
-    display: flex;
-    transition: all 0.5s ease-out;
-    background-color: rgb(84, 83, 83);
-    justify-content: space-between;
-    padding: 24px;
-    max-width: 60vw;
-    font-size: 24px;
-    margin: 20px auto;
-    cursor: pointer;
+.faqbox {
+  display: flex;
+  transition: all 0.5s ease-out;
+  background-color: var(--faq-box-bg);
+  justify-content: space-between;
+  padding: 24px;
+  max-width: 60vw;
+  font-size: 24px;
+  margin: 20px auto;
+  cursor: pointer;
 }
-footer{
-    color: white;
-    max-width: 60vw;
-    margin: auto;
-    padding: 14px;
+footer {
+  background-color: var(--section-bg);
+  color: var(--section-text-color);
+  max-width: 100vw;
+  margin: 0;
+  padding: 14px;
 }
-.footer{
+.footer {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  color: var(--section-text-color);
+}
+@media screen and (max-width: 1300px) {
+  .footer {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr 1fr;
-    color: white;
+    grid-template-columns: 1fr 1fr;
+    color: var(--section-text-color);
+    gap: 25px;
+  }
 }
-@media screen and (max-width:1300px){
-    .footer{
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        color: white;
-        gap: 25px;
-    }
+.footer-item {
+  display: flex;
+  flex-direction: column;
+  gap: 23px;
 }
-.footer-item{
-    display: flex;
-    flex-direction: column;
-    gap: 23px;
+.footer a {
+  text-decoration: none;
+  color: var(--section-text-color);
+  font-size: 14px;
 }
-.footer a{
-    text-decoration: none;
-    color: white;
-    font-size: 14px;
-}
-footer .questions{
-    padding: 34px 0;
+footer .questions {
+  padding: 34px 0;
 }
 #chatbot-widget {
   position: fixed;
   bottom: 30px;
   right: 30px;
   z-index: 1000;
-  font-family: 'Segoe UI', Arial, sans-serif;
+  font-family: "Segoe UI", Arial, sans-serif;
 }
 #chatbot-toggle {
   background: #e50914;
@@ -311,7 +370,7 @@ footer .questions{
   height: 56px;
   font-size: 2rem;
   cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   transition: background 0.2s;
 }
 #chatbot-toggle:hover {
@@ -324,7 +383,7 @@ footer .questions{
   background: #181818;
   color: #fff;
   border-radius: 18px;
-  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
   position: absolute;
   bottom: 70px;
   right: 0;
@@ -334,8 +393,14 @@ footer .questions{
   animation: fadeIn 0.3s;
 }
 @keyframes fadeIn {
-  from { opacity: 0; transform: translateY(30px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 #chatbot-header {
   background: #e50914;
@@ -380,7 +445,7 @@ footer .questions{
   font-size: 1rem;
   line-height: 1.5;
   margin-bottom: 2px;
-  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
   word-break: break-word;
 }
 .chat-message.user .bubble {
@@ -415,8 +480,12 @@ footer .questions{
   animation: spin 1s linear infinite;
 }
 @keyframes spin {
-  0% { transform: rotate(0deg); }
-  100% { transform: rotate(360deg); }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 #chatbot-form {
   display: flex;


### PR DESCRIPTION
This pull request introduces a new light/dark mode toggle feature, allowing users to switch between themes for an improved viewing experience.

**Key Changes Include:**

* **Theme Toggle Functionality:** Added a clickable button (with sun/moon icons) that dynamically changes the `data-theme` attribute on the `<body>` element.
* **Persistent Theme Preference:** Utilizes `localStorage` to remember the user's last selected theme, applying it automatically on subsequent visits.
* **CSS Variable Integration:** Leveraged CSS custom properties (variables) to manage theme-specific colors and styles efficiently. A few existing features had a default dark mode appearance, so made adjustments to the CSS variables to ensure all elements properly adapt to both light and dark themes.
    * Updated `:root` variables for dark mode defaults.
    * Defined `body[data-theme="light"]` overrides for light mode styles.
 * **Code Formatting:** Please note that a code formatter (Prettier) was run, which introduced some minor stylistic changes across the affected files.

This enhancement aims to provide users with more control over their visual experience.