### PR TITLE
Fix: Adjusted button text layout and padding in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -228,6 +228,13 @@ nav button {
 .btn-red-sm {
   background-color: var(--btn-red-bg);
   color: var(--btn-red-text);
+  padding: 8px 16px;             
+  line-height: 1.2;               
+  white-space: nowrap;            
+  display: inline-block;          
+  height: auto;                   
+  overflow: visible;              
+  writing-mode: horizontal-tb;    
 }
 
 .btn-lang .language-switch,


### PR DESCRIPTION

![IMG_20250731_233033](https://github.com/user-attachments/assets/a8d5c2aa-3dba-4b68-a23b-c0aa8ab774fc)
Reopening due to accidental reset. This PR restores the original CSS fix made earlier.